### PR TITLE
EVG-12675 use interface for mongoDB versions

### DIFF
--- a/catalog.go
+++ b/catalog.go
@@ -169,11 +169,11 @@ func (c *BuildCatalog) Get(version, edition, target, arch string, debug bool) (s
 			// targets are "osx". However, starting in 4.1.1, OSX targets are
 			// "macos".
 			if runtime.GOOS == "darwin" {
-				parsedVersion, err := NewMongoDBVersion(version)
+				parsedVersion, err := CreateMongoDBVersion(version)
 				if err != nil {
 					return "", errors.Wrap(err, "could not parse version")
 				}
-				macosVersion, err := NewMongoDBVersion("4.1.1")
+				macosVersion, err := CreateMongoDBVersion("4.1.1")
 				if err != nil {
 					return "", errors.Wrap(err, "could not parse version for comparison")
 				}

--- a/feed.go
+++ b/feed.go
@@ -73,7 +73,7 @@ func NewArtifactsFeed(path string) (*ArtifactsFeed, error) {
 		// if the thing we think should be the json file
 		// exists but isn't a file (i.e. directory,) then this
 		// should be an error.
-		return nil, errors.Errorf("path %s not a json file  directory", path)
+		return nil, errors.Errorf("path %s not a json file directory", path)
 	}
 
 	return f, nil
@@ -109,7 +109,6 @@ func (feed *ArtifactsFeed) Reload(data []byte) error {
 		return errors.Wrap(err, "problem converting data from json")
 	}
 
-	// this is a reload rather than a new load, and we shoiuld
 	if len(feed.table) > 0 {
 		feed.table = make(map[string]*ArtifactVersion)
 	}

--- a/fetch.go
+++ b/fetch.go
@@ -30,7 +30,7 @@ func createDirectory(path string) error {
 }
 
 // CacheDownload downloads a resource (url) into a file (path); if the
-// file already exists CaceheDownlod does not download a new copy of
+// file already exists CacheDownload does not download a new copy of
 // the file, unless local file is older than the ttl, or the force
 // option is specified. CacheDownload returns the contents of the file.
 func CacheDownload(ctx context.Context, ttl time.Duration, url, path string, force bool) ([]byte, error) {

--- a/version.go
+++ b/version.go
@@ -10,7 +10,7 @@ import (
 
 // ArtifactVersion represents a document in the Version field of the
 // MongoDB build information feed. See
-// http://downloads.mongodb.org/full.json for an example.ownload
+// http://downloads.mongodb.org/full.json for an example download
 type ArtifactVersion struct {
 	Version   string
 	Downloads []ArtifactDownload
@@ -51,11 +51,11 @@ func (version *ArtifactVersion) GetDownload(key BuildOptions) (ArtifactDownload,
 	// For OSX, the target depends on the version. Before 4.1, OSX targets are
 	// "osx". However, starting in 4.1.1, OSX targets are "macos".
 	if key.Target == "osx" {
-		parsedVersion, err := NewMongoDBVersion(version.Version)
+		parsedVersion, err := CreateMongoDBVersion(version.Version)
 		if err != nil {
 			return ArtifactDownload{}, errors.Wrap(err, "could not parse version")
 		}
-		macosVersion, err := NewMongoDBVersion("4.1.1")
+		macosVersion, err := CreateMongoDBVersion("4.1.1")
 		if err != nil {
 			return ArtifactDownload{}, errors.Wrap(err, "could not parse version for comparison")
 		}

--- a/versions.go
+++ b/versions.go
@@ -1,7 +1,7 @@
 /*
 MongoDB Versions
 
-The LegacyMongoDBVersion type provides support for interacting with MongoDB
+The MongoDBVersion type provides support for interacting with MongoDB
 versions. This type makes it possible to validate MongoDB version
 numbers and ask common questions about MongoDB versions.
 */
@@ -19,7 +19,7 @@ import (
 
 const endOfLegacy = "4.5.0"
 
-// MongoDBVersion encapsulates information about a MongoDBVersion.
+// MongoDBVersion encapsulates information about a MongoDB version.
 // Use the associated methods to ask questions about MongoDB
 // versions. All parsing of versions happens during construction, and
 // individual method calls are very light-weight. Note that
@@ -27,11 +27,11 @@ const endOfLegacy = "4.5.0"
 type MongoDBVersion interface {
 	// String returns a string representation of the MongoDB version number.
 	String() string
-	// Parsed returns the parsed version object for the version
+	// Parsed returns the parsed version object for the version.
 	Parsed() semver.Version
 	// Series returns the release series for legacy versions.
 	Series() string
-	// IsReleaseCandidate returns true if the version is a release candidate.
+	// IsReleaseCandidate returns true if the legacy version is a release candidate.
 	IsReleaseCandidate() bool
 	// IsStableSeries returns true if the legacy version is a stable series.
 	IsStableSeries() bool
@@ -46,8 +46,8 @@ type MongoDBVersion interface {
 	// IsInitialStableReleaseCandidate returns true if the legacy version is a release
 	// candidate for the initial release of a stable series.
 	IsInitialStableReleaseCandidate() bool
-	// RcNumber returns the RC counter (or -1 if not a release candidate)
-	RcNumber() int
+	// RCNumber returns the RC counter (or -1 if not a release candidate)
+	RCNumber() int
 
 	IsLessThan(version MongoDBVersion) bool
 	IsLessThanOrEqualTo(version MongoDBVersion) bool
@@ -76,6 +76,9 @@ type NewMongoDBVersion struct {
 	LegacyMongoDBVersion
 }
 
+// CreateMongoDBVersion returns an implementation of the MongoDBVersion.
+// If the parsed version is before 4.5.0, then we use the legacy structure.
+// Otherwise, we use the modern versioning scheme.
 func CreateMongoDBVersion(version string) (MongoDBVersion, error) {
 	endOfLegacyVersion, _ := semver.Parse(endOfLegacy)
 
@@ -99,15 +102,16 @@ func CreateMongoDBVersion(version string) (MongoDBVersion, error) {
 	return createNewMongoDBVersion(version)
 }
 
+
+// createNewMongoDBVersion takes a string representing a MongoDBVersion and
+// returns a NewMongoDBVersion object. All parsing of a version happens during this phase.
 func createNewMongoDBVersion(version string) (*NewMongoDBVersion, error) {
 	return nil, errors.New("not yet implemented")
 }
 
 
-// CreateMongoDBVersion takes a string representing a MongoDB version and
-// returns a LegacyMongoDBVersion object. If the input string is not a valid
-// version, or there were problems parsing the string, the error value
-// is non-nil. All parsing of a version happens during this phase.
+// createLegacyMongoDBVersion takes a string representing a MongoDB version and
+// returns a LegacyMongoDBVersion object. All parsing of a version happens during this phase.
 func createLegacyMongoDBVersion(version string) (*LegacyMongoDBVersion, error) {
 	v := &LegacyMongoDBVersion{source: version, rcNumber: -1}
 	if strings.HasSuffix(version, "-") {
@@ -190,6 +194,7 @@ func (v *LegacyMongoDBVersion) String() string {
 	return v.source
 }
 
+// Parsed returns the parsed version object for the version.
 func (v *LegacyMongoDBVersion) Parsed() semver.Version {
 	return v.parsed
 }
@@ -263,9 +268,9 @@ func (v *LegacyMongoDBVersion) IsInitialStableReleaseCandidate() bool {
 	return false
 }
 
-// RcNumber returns an integer for the RC counter. For non-rc releases,
+// RCNumber returns an integer for the RC counter. For non-rc releases,
 // returns -1.
-func (v *LegacyMongoDBVersion) RcNumber() int {
+func (v *LegacyMongoDBVersion) RCNumber() int {
 	return v.rcNumber
 }
 

--- a/versions.go
+++ b/versions.go
@@ -1,7 +1,7 @@
 /*
 MongoDB Versions
 
-The MongoDBVersion type provides support for interacting with MongoDB
+The LegacyMongoDBVersion type provides support for interacting with MongoDB
 versions. This type makes it possible to validate MongoDB version
 numbers and ask common questions about MongoDB versions.
 */
@@ -9,6 +9,7 @@ package bond
 
 import (
 	"fmt"
+	"github.com/pkg/errors"
 	"sort"
 	"strconv"
 	"strings"
@@ -16,11 +17,50 @@ import (
 	"github.com/blang/semver"
 )
 
-// MongoDBVersion is a structure representing a version identifier for
-// MongoDB. Use the associated methods to ask questions about MongoDB
+const endOfLegacy = "4.5.0"
+
+// MongoDBVersion encapsulates information about a MongoDBVersion.
+// Use the associated methods to ask questions about MongoDB
 // versions. All parsing of versions happens during construction, and
-// individual method calls are very light-weight.
-type MongoDBVersion struct {
+// individual method calls are very light-weight. Note that
+// not all methods are applicable for all versions.
+type MongoDBVersion interface {
+	// String returns a string representation of the MongoDB version number.
+	String() string
+	// Parsed returns the parsed version object for the version
+	Parsed() semver.Version
+	// Series returns the release series for legacy versions.
+	Series() string
+	// IsReleaseCandidate returns true if the version is a release candidate.
+	IsReleaseCandidate() bool
+	// IsStableSeries returns true if the legacy version is a stable series.
+	IsStableSeries() bool
+	// IsDevelopmentSeries returns true if the legacy version is a development series.
+	IsDevelopmentSeries() bool
+	// StableReleaseSeries returns true if the legacy version is a stable release series.
+	StableReleaseSeries() string
+	// IsRelease returns true if the version is a release.
+	IsRelease() bool
+	// IsDevelopmentBuild returns true for non-release versions.
+	IsDevelopmentBuild() bool
+	// IsInitialStableReleaseCandidate returns true if the legacy version is a release
+	// candidate for the initial release of a stable series.
+	IsInitialStableReleaseCandidate() bool
+	// RcNumber returns the RC counter (or -1 if not a release candidate)
+	RcNumber() int
+
+	IsLessThan(version MongoDBVersion) bool
+	IsLessThanOrEqualTo(version MongoDBVersion) bool
+	IsGreaterThan(version MongoDBVersion) bool
+	IsGreaterThanOrEqualTo(version MongoDBVersion) bool
+	IsEqualTo(version MongoDBVersion) bool
+	IsNotEqualTo(version MongoDBVersion) bool
+
+}
+
+// LegacyMongoDBVersion is a structure representing a version identifier for legacy versions of
+// MongoDB, which implements the MongoDBVersion interface.
+type LegacyMongoDBVersion struct {
 	source   string
 	parsed   semver.Version
 	isRc     bool
@@ -30,13 +70,46 @@ type MongoDBVersion struct {
 	tag      string
 }
 
-// NewMongoDBVersion takes a string representing a MongoDB version and
-// returns a MongoDBVersion object. If the input string is not a valid
+// NewMongoDBVersion is a structure representing a version identifier for versions of
+// MongoDB, which implements the MongoDBVersion.
+type NewMongoDBVersion struct {
+	LegacyMongoDBVersion
+}
+
+func CreateMongoDBVersion(version string) (MongoDBVersion, error) {
+	endOfLegacyVersion, _ := semver.Parse(endOfLegacy)
+
+	// pre-processing to then determine which version to use
+	toParse := version
+	if strings.HasSuffix(version, "-") && !strings.Contains(version, "pre") {
+			toParse += "pre-"
+	}
+	if strings.Contains(toParse, "~") {
+		versionParts := strings.Split(version, "~")
+		toParse = versionParts[0]
+	}
+
+	parsed, err := semver.Parse(toParse)
+	if err != nil {
+		return nil, err
+	}
+	if parsed.LT(endOfLegacyVersion) {
+		return createLegacyMongoDBVersion(version)
+	}
+	return createNewMongoDBVersion(version)
+}
+
+func createNewMongoDBVersion(version string) (*NewMongoDBVersion, error) {
+	return nil, errors.New("not yet implemented")
+}
+
+
+// CreateMongoDBVersion takes a string representing a MongoDB version and
+// returns a LegacyMongoDBVersion object. If the input string is not a valid
 // version, or there were problems parsing the string, the error value
 // is non-nil. All parsing of a version happens during this phase.
-func NewMongoDBVersion(version string) (*MongoDBVersion, error) {
-	v := &MongoDBVersion{source: version, rcNumber: -1}
-
+func createLegacyMongoDBVersion(version string) (*LegacyMongoDBVersion, error) {
+	v := &LegacyMongoDBVersion{source: version, rcNumber: -1}
 	if strings.HasSuffix(version, "-") {
 		v.isDev = true
 
@@ -86,20 +159,26 @@ func NewMongoDBVersion(version string) (*MongoDBVersion, error) {
 
 // ConvertVersion takes an un-typed object and attempts to convert it to a
 // version object. For use with compactor functions.
-func ConvertVersion(v interface{}) (*MongoDBVersion, error) {
+func ConvertVersion(v interface{}) (MongoDBVersion, error) {
 	switch version := v.(type) {
-	case *MongoDBVersion:
+	case *LegacyMongoDBVersion:
 		return version, nil
-	case MongoDBVersion:
+	case LegacyMongoDBVersion:
 		return &version, nil
+	case *NewMongoDBVersion:
+		return version, nil
+	case NewMongoDBVersion:
+		return &version, nil
+	case MongoDBVersion:
+		return version, nil
 	case string:
-		output, err := NewMongoDBVersion(version)
+		output, err := CreateMongoDBVersion(version)
 		if err != nil {
 			return nil, err
 		}
 		return output, nil
 	case semver.Version:
-		return NewMongoDBVersion(version.String())
+		return CreateMongoDBVersion(version.String())
 	default:
 		return nil, fmt.Errorf("%v is not a valid version type (%T)", version, version)
 	}
@@ -107,26 +186,30 @@ func ConvertVersion(v interface{}) (*MongoDBVersion, error) {
 
 // String returns a string representation of the MongoDB version
 // number.
-func (v *MongoDBVersion) String() string {
+func (v *LegacyMongoDBVersion) String() string {
 	return v.source
+}
+
+func (v *LegacyMongoDBVersion) Parsed() semver.Version {
+	return v.parsed
 }
 
 // Series return the release series, generally the first two
 // components of a version. For example for 3.2.6, the series is 3.2.
-func (v *MongoDBVersion) Series() string {
+func (v *LegacyMongoDBVersion) Series() string {
 	return v.series
 }
 
 // IsReleaseCandidate returns true for releases that have the "rc[0-9]"
 // tag and false otherwise.
-func (v *MongoDBVersion) IsReleaseCandidate() bool {
+func (v *LegacyMongoDBVersion) IsReleaseCandidate() bool {
 	return v.IsRelease() && v.isRc
 }
 
 // IsStableSeries returns true for stable releases, ones where the
 // second component of the version string (i.e. "Minor" in semantic
 // versioning terms) are even, and false otherwise.
-func (v *MongoDBVersion) IsStableSeries() bool {
+func (v *LegacyMongoDBVersion) IsStableSeries() bool {
 	return v.parsed.Minor%2 == 0
 }
 
@@ -134,7 +217,7 @@ func (v *MongoDBVersion) IsStableSeries() bool {
 // releases. These versions are those where the second component
 // (e.g. "Minor" in semantic versioning terms) are odd, and false
 // otherwise.
-func (v *MongoDBVersion) IsDevelopmentSeries() bool {
+func (v *LegacyMongoDBVersion) IsDevelopmentSeries() bool {
 	return !v.IsStableSeries()
 }
 
@@ -142,7 +225,7 @@ func (v *MongoDBVersion) IsDevelopmentSeries() bool {
 // version. For stable releases, the output is the same as
 // .Series(). For development releases, this method returns the *next*
 // stable series.
-func (v *MongoDBVersion) StableReleaseSeries() string {
+func (v *LegacyMongoDBVersion) StableReleaseSeries() string {
 	if v.IsStableSeries() {
 		return v.Series()
 	}
@@ -159,21 +242,21 @@ func (v *MongoDBVersion) StableReleaseSeries() string {
 // and false otherwise. Other builds, including test builds and
 // "nightly" snapshots of MongoDB have version strings, but are not
 // releases.
-func (v *MongoDBVersion) IsRelease() bool {
+func (v *LegacyMongoDBVersion) IsRelease() bool {
 	return !v.isDev
 }
 
 // IsDevelopmentBuild returns true for all non-release builds,
 // including nightly snapshots and all testing and development
 // builds.
-func (v *MongoDBVersion) IsDevelopmentBuild() bool {
+func (v *LegacyMongoDBVersion) IsDevelopmentBuild() bool {
 	return v.isDev
 }
 
 // IsInitialStableReleaseCandidate returns true for release
 // candidates for the initial public release of a new stable release
 // series.
-func (v *MongoDBVersion) IsInitialStableReleaseCandidate() bool {
+func (v *LegacyMongoDBVersion) IsInitialStableReleaseCandidate() bool {
 	if v.IsStableSeries() {
 		return v.parsed.Patch == 0 && v.IsReleaseCandidate()
 	}
@@ -182,53 +265,53 @@ func (v *MongoDBVersion) IsInitialStableReleaseCandidate() bool {
 
 // RcNumber returns an integer for the RC counter. For non-rc releases,
 // returns -1.
-func (v *MongoDBVersion) RcNumber() int {
+func (v *LegacyMongoDBVersion) RcNumber() int {
 	return v.rcNumber
 }
 
 // IsLessThan returns true when "version" is less than (e.g. earlier)
 // than the object itself.
-func (v *MongoDBVersion) IsLessThan(version *MongoDBVersion) bool {
-	return v.parsed.LT(version.parsed)
+func (v *LegacyMongoDBVersion) IsLessThan(version MongoDBVersion) bool {
+	return v.Parsed().LT(version.Parsed())
 }
 
 // IsLessThanOrEqualTo returns true when "version" is less than or
 // equal to (e.g. earlier or the same as) the object itself.
-func (v *MongoDBVersion) IsLessThanOrEqualTo(version *MongoDBVersion) bool {
+func (v *LegacyMongoDBVersion) IsLessThanOrEqualTo(version MongoDBVersion) bool {
 	// semver considers release candidates equal to GA, so we have to special case this
 
 	if v.IsEqualTo(version) {
 		return true
 	}
 
-	return v.parsed.LT(version.parsed)
+	return v.Parsed().LT(version.Parsed())
 }
 
 // IsGreaterThan returns true when "version" is greater than (e.g. later)
 // than the object itself.
-func (v *MongoDBVersion) IsGreaterThan(version *MongoDBVersion) bool {
-	return v.parsed.GT(version.parsed)
+func (v *LegacyMongoDBVersion) IsGreaterThan(version MongoDBVersion) bool {
+	return v.Parsed().GT(version.Parsed())
 }
 
 // IsGreaterThanOrEqualTo returns true when "version" is greater than
 // or equal to (e.g. the same as or later than) the object itself.
-func (v *MongoDBVersion) IsGreaterThanOrEqualTo(version *MongoDBVersion) bool {
+func (v *LegacyMongoDBVersion) IsGreaterThanOrEqualTo(version MongoDBVersion) bool {
 	if v.IsEqualTo(version) {
 		return true
 	}
-	return v.parsed.GT(version.parsed)
+	return v.Parsed().GT(version.Parsed())
 }
 
 // IsEqualTo returns true when "version" is the same as the object
 // itself.
-func (v *MongoDBVersion) IsEqualTo(version *MongoDBVersion) bool {
-	return v.source == version.source
+func (v *LegacyMongoDBVersion) IsEqualTo(version MongoDBVersion) bool {
+	return v.String() == version.String()
 }
 
 // IsNotEqualTo returns true when "version" is the different from the
 // object itself.
-func (v *MongoDBVersion) IsNotEqualTo(version *MongoDBVersion) bool {
-	return v.source != version.source
+func (v *LegacyMongoDBVersion) IsNotEqualTo(version MongoDBVersion) bool {
+	return v.String() != version.String()
 }
 
 /////////////////////////////////////////////
@@ -254,7 +337,7 @@ func (s MongoDBVersionSlice) Less(i, j int) bool {
 	left := s[i]
 	right := s[j]
 
-	return left.parsed.LT(right.parsed)
+	return left.Parsed().LT(right.Parsed())
 }
 
 // Swap is a required by the sort.Sorter interface. Changes the
@@ -270,12 +353,12 @@ func (s MongoDBVersionSlice) String() string {
 	var out []string
 
 	for _, v := range s {
-		if len(v.source) == 0 {
+		if len(v.String()) == 0 {
 			// some elements end up empty.
 			continue
 		}
 
-		out = append(out, v.source)
+		out = append(out, v.String())
 	}
 
 	return strings.Join(out, ", ")

--- a/versions.go
+++ b/versions.go
@@ -94,7 +94,7 @@ func CreateMongoDBVersion(version string) (MongoDBVersion, error) {
 
 	parsed, err := semver.Parse(toParse)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "error parsing %s'", toParse)
 	}
 	if parsed.LT(endOfLegacyVersion) {
 		return createLegacyMongoDBVersion(version)
@@ -131,7 +131,7 @@ func createLegacyMongoDBVersion(version string) (*LegacyMongoDBVersion, error) {
 
 	parsed, err := semver.Parse(version)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "error parsing '%s'", version)
 	}
 	v.parsed = parsed
 

--- a/versions_test.go
+++ b/versions_test.go
@@ -8,14 +8,14 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-// VersionSuite contains tests of both the MongoDBVersion
+// VersionSuite contains tests of both the LegacyMongoDBVersion
 // representation and the MongoDBVersionSlice type which implements
 // the sort.Sorter interface. These tests confirm that the
-// NewMongoDBVersion constructor is capable of validating MongoDB
+// CreateMongoDBVersion constructor is capable of validating MongoDB
 // versions, and that methods associated with report the expected
 // properties for a given version string.
 type VersionSuite struct {
-	baseVersion *MongoDBVersion
+	baseVersion MongoDBVersion
 	suite.Suite
 }
 
@@ -24,7 +24,7 @@ func TestVersionSuite(t *testing.T) {
 }
 
 func (s *VersionSuite) SetupSuite() {
-	base, err := NewMongoDBVersion("3.2.6")
+	base, err := CreateMongoDBVersion("3.2.6")
 	s.NoError(err)
 	s.baseVersion = base
 }
@@ -43,7 +43,7 @@ func (s *VersionSuite) TestValidVersionsParseWithoutErrors() {
 		"3.0.1-pre-",
 	}
 	for _, version := range versions {
-		_, err := NewMongoDBVersion(version)
+		_, err := CreateMongoDBVersion(version)
 		s.NoError(err)
 	}
 }
@@ -63,7 +63,7 @@ func (s *VersionSuite) TestInvalidVersionsHaveParseErrors() {
 	}
 
 	for _, version := range versions {
-		v, err := NewMongoDBVersion(version)
+		v, err := CreateMongoDBVersion(version)
 		s.Error(err)
 		s.Nil(v)
 	}
@@ -79,9 +79,9 @@ func (s *VersionSuite) TestVersionParserIdentifiesReleaseCandidates() {
 	}
 
 	for _, version := range rcs {
-		v, err := NewMongoDBVersion(version)
+		v, err := CreateMongoDBVersion(version)
 		s.NoError(err)
-		s.True(v.IsReleaseCandidate(), v.source)
+		s.True(v.IsReleaseCandidate(), v.String())
 	}
 
 	notRcs := []string{
@@ -98,7 +98,7 @@ func (s *VersionSuite) TestVersionParserIdentifiesReleaseCandidates() {
 	}
 
 	for _, version := range notRcs {
-		v, err := NewMongoDBVersion(version)
+		v, err := CreateMongoDBVersion(version)
 		s.NoError(err)
 		s.False(v.IsReleaseCandidate())
 		s.False(v.IsInitialStableReleaseCandidate())
@@ -125,7 +125,7 @@ func (s *VersionSuite) TestReleaseSeriesDetection() {
 	}
 
 	for _, value := range values {
-		v, err := NewMongoDBVersion(value.input)
+		v, err := CreateMongoDBVersion(value.input)
 		s.NoError(err)
 		s.Equal(v.Series(), value.expected)
 	}
@@ -143,7 +143,7 @@ func (s *VersionSuite) TestStableAndDevReleaseSeriesAttributes() {
 	}
 
 	for _, version := range versions {
-		v, err := NewMongoDBVersion(version)
+		v, err := CreateMongoDBVersion(version)
 		s.NoError(err)
 		s.True(v.IsStableSeries())
 		s.False(v.IsDevelopmentSeries())
@@ -160,7 +160,7 @@ func (s *VersionSuite) TestStableAndDevReleaseSeriesAttributes() {
 	}
 
 	for _, version := range devVersion {
-		v, err := NewMongoDBVersion(version)
+		v, err := CreateMongoDBVersion(version)
 		s.NoError(err)
 		s.True(v.IsDevelopmentSeries())
 		s.False(v.IsStableSeries())
@@ -179,7 +179,7 @@ func (s *VersionSuite) TestVersionCanIdentifyReleases() {
 	}
 
 	for _, version := range releases {
-		v, err := NewMongoDBVersion(version)
+		v, err := CreateMongoDBVersion(version)
 		s.NoError(err)
 		s.True(v.IsRelease())
 		s.False(v.IsDevelopmentBuild())
@@ -193,7 +193,7 @@ func (s *VersionSuite) TestVersionCanIdentifyReleases() {
 	}
 
 	for _, version := range builds {
-		v, err := NewMongoDBVersion(version)
+		v, err := CreateMongoDBVersion(version)
 		s.NoError(err)
 		s.True(v.IsDevelopmentBuild())
 		s.False(v.IsRelease())
@@ -214,7 +214,7 @@ func (s *VersionSuite) TestDistinguishInitialStableVersionRC() {
 	}
 
 	for _, version := range releases {
-		v, err := NewMongoDBVersion(version)
+		v, err := CreateMongoDBVersion(version)
 		s.NoError(err)
 		s.True(v.IsReleaseCandidate())
 		s.True(v.IsInitialStableReleaseCandidate(), version)
@@ -231,7 +231,7 @@ func (s *VersionSuite) TestDistinguishInitialStableVersionRC() {
 	}
 
 	for _, version := range otherRcs {
-		v, err := NewMongoDBVersion(version)
+		v, err := CreateMongoDBVersion(version)
 		s.NoError(err)
 		s.True(v.IsReleaseCandidate())
 		s.False(v.IsInitialStableReleaseCandidate())
@@ -256,9 +256,9 @@ func (s *VersionSuite) TestSortingVersions() {
 	for _, value := range values {
 		var v []MongoDBVersion
 		for _, input := range value.input {
-			version, err := NewMongoDBVersion(input)
+			version, err := CreateMongoDBVersion(input)
 			s.NoError(err)
-			v = append(v, *version)
+			v = append(v, version)
 		}
 
 		versions := MongoDBVersionSlice(v)
@@ -278,10 +278,10 @@ func (s *VersionSuite) TestVersionSliceStringFormating() {
 	versions := []string{"3.2.1", "2.6.18", "2.4.3", "1.8.4"}
 	slice := make(MongoDBVersionSlice, len(versions))
 
-	for _, v := range versions {
-		ver, err := NewMongoDBVersion(v)
+	for i, v := range versions {
+		ver, err := CreateMongoDBVersion(v)
 		s.NoError(err)
-		slice = append(slice, *ver)
+		slice[i] = ver
 	}
 
 	s.Equal(strings.Join(versions, ", "), slice.String())
@@ -292,12 +292,12 @@ func (s *VersionSuite) TestParsingIdentifiesRCForRCs() {
 		"3.2.0-rc0":  0,
 		"2.4.0-rc42": 42,
 		"1.8.4-rc1":  1,
-		"4.6.1-rc12": 12,
+		"4.4.1-rc12": 12,
 	}
 
 	for version, rcNumber := range cases {
-		v, err := NewMongoDBVersion(version)
-		s.NoError(err)
+		v, err := CreateMongoDBVersion(version)
+		s.Require().NoError(err)
 		s.Equal(v.RcNumber(), rcNumber)
 	}
 
@@ -310,7 +310,7 @@ func (s *VersionSuite) TestRCNumberIsLessThanZeroForNonRCs() {
 	}
 
 	for _, version := range cases {
-		v, err := NewMongoDBVersion(version)
+		v, err := CreateMongoDBVersion(version)
 		s.NoError(err)
 		s.True(v.RcNumber() < 0)
 	}
@@ -322,22 +322,25 @@ func (s *VersionSuite) TestVersionConversionProducesExpectedVersionObjectsWithou
 	// should convert a string to a version object.
 	vString, err := ConvertVersion(expectedVersion)
 	s.NoError(err)
-	s.Equal(vString.source, expectedVersion)
+	s.Equal(vString.String(), expectedVersion)
 
 	// pass a pointer to a version object the converter
 	vVersionPointer, err := ConvertVersion(vString)
 	s.NoError(err)
-	s.Equal(vVersionPointer.source, expectedVersion)
+	s.Equal(vVersionPointer.String(), expectedVersion)
 
-	// pass a version object itself rather than a ref.
-	vVersionObj, err := ConvertVersion(*vVersionPointer)
+	// pass a legacy version object itself rather than a ref.
+	vVersionLegacy, ok := vVersionPointer.(*LegacyMongoDBVersion)
+	s.True(ok)
+	s.NotNil(vVersionLegacy)
+	vVersionObj, err := ConvertVersion(*vVersionLegacy)
 	s.NoError(err)
-	s.Equal(vVersionObj.source, expectedVersion)
+	s.Equal(vVersionObj.String(), expectedVersion)
 
 	// try a smevar.Version object
-	vSemVar, err := ConvertVersion(vVersionObj.parsed)
+	vSemVar, err := ConvertVersion(vVersionObj.Parsed())
 	s.NoError(err)
-	s.Equal(vSemVar.source, expectedVersion)
+	s.Equal(vSemVar.String(), expectedVersion)
 }
 
 func (s *VersionSuite) TestVersionConverterErrorsForInvalidVersions() {
@@ -374,11 +377,11 @@ func (s *VersionSuite) TestLessThanComparator() {
 			s.True(s.baseVersion.IsGreaterThanOrEqualTo(v))
 		} else {
 			s.False(v.IsLessThan(s.baseVersion))
-			if v.source == s.baseVersion.source {
+			if v.String() == s.baseVersion.String() {
 				continue
 			}
 			s.False(s.baseVersion.IsGreaterThanOrEqualTo(v),
-				fmt.Sprintf("%s %s", s.baseVersion.source, v.source))
+				fmt.Sprintf("%s %s", s.baseVersion.String(), v.String()))
 		}
 	}
 }
@@ -402,12 +405,12 @@ func (s *VersionSuite) TestLessThanOrEqualToComparator() {
 			s.True(v.IsLessThanOrEqualTo(s.baseVersion))
 
 			// test inverse
-			if v.source == s.baseVersion.source {
+			if v.String() == s.baseVersion.String() {
 				continue
 			}
 
 			s.True(s.baseVersion.IsGreaterThan(v), fmt.Sprintf("%s == %s",
-				v.source, s.baseVersion.source))
+				v.String(), s.baseVersion.String()))
 		} else {
 			s.False(v.IsLessThanOrEqualTo(s.baseVersion))
 

--- a/versions_test.go
+++ b/versions_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-// VersionSuite contains tests of both the LegacyMongoDBVersion
+// VersionSuite contains tests of both the MongoDBVersion
 // representation and the MongoDBVersionSlice type which implements
 // the sort.Sorter interface. These tests confirm that the
 // CreateMongoDBVersion constructor is capable of validating MongoDB
@@ -81,6 +81,7 @@ func (s *VersionSuite) TestVersionParserIdentifiesReleaseCandidates() {
 	for _, version := range rcs {
 		v, err := CreateMongoDBVersion(version)
 		s.NoError(err)
+		s.Require().NotNil(v)
 		s.True(v.IsReleaseCandidate(), v.String())
 	}
 
@@ -100,6 +101,7 @@ func (s *VersionSuite) TestVersionParserIdentifiesReleaseCandidates() {
 	for _, version := range notRcs {
 		v, err := CreateMongoDBVersion(version)
 		s.NoError(err)
+		s.Require().NotNil(v)
 		s.False(v.IsReleaseCandidate())
 		s.False(v.IsInitialStableReleaseCandidate())
 	}
@@ -127,6 +129,7 @@ func (s *VersionSuite) TestReleaseSeriesDetection() {
 	for _, value := range values {
 		v, err := CreateMongoDBVersion(value.input)
 		s.NoError(err)
+		s.Require().NotNil(v)
 		s.Equal(v.Series(), value.expected)
 	}
 }
@@ -145,6 +148,7 @@ func (s *VersionSuite) TestStableAndDevReleaseSeriesAttributes() {
 	for _, version := range versions {
 		v, err := CreateMongoDBVersion(version)
 		s.NoError(err)
+		s.Require().NotNil(v)
 		s.True(v.IsStableSeries())
 		s.False(v.IsDevelopmentSeries())
 	}
@@ -162,6 +166,7 @@ func (s *VersionSuite) TestStableAndDevReleaseSeriesAttributes() {
 	for _, version := range devVersion {
 		v, err := CreateMongoDBVersion(version)
 		s.NoError(err)
+		s.Require().NotNil(v)
 		s.True(v.IsDevelopmentSeries())
 		s.False(v.IsStableSeries())
 	}
@@ -181,6 +186,7 @@ func (s *VersionSuite) TestVersionCanIdentifyReleases() {
 	for _, version := range releases {
 		v, err := CreateMongoDBVersion(version)
 		s.NoError(err)
+		s.Require().NotNil(v)
 		s.True(v.IsRelease())
 		s.False(v.IsDevelopmentBuild())
 	}
@@ -195,6 +201,7 @@ func (s *VersionSuite) TestVersionCanIdentifyReleases() {
 	for _, version := range builds {
 		v, err := CreateMongoDBVersion(version)
 		s.NoError(err)
+		s.Require().NotNil(v)
 		s.True(v.IsDevelopmentBuild())
 		s.False(v.IsRelease())
 	}
@@ -216,6 +223,7 @@ func (s *VersionSuite) TestDistinguishInitialStableVersionRC() {
 	for _, version := range releases {
 		v, err := CreateMongoDBVersion(version)
 		s.NoError(err)
+		s.Require().NotNil(v)
 		s.True(v.IsReleaseCandidate())
 		s.True(v.IsInitialStableReleaseCandidate(), version)
 	}
@@ -233,6 +241,7 @@ func (s *VersionSuite) TestDistinguishInitialStableVersionRC() {
 	for _, version := range otherRcs {
 		v, err := CreateMongoDBVersion(version)
 		s.NoError(err)
+		s.Require().NotNil(v)
 		s.True(v.IsReleaseCandidate())
 		s.False(v.IsInitialStableReleaseCandidate())
 	}
@@ -258,6 +267,7 @@ func (s *VersionSuite) TestSortingVersions() {
 		for _, input := range value.input {
 			version, err := CreateMongoDBVersion(input)
 			s.NoError(err)
+			s.Require().NotNil(version)
 			v = append(v, version)
 		}
 
@@ -281,6 +291,7 @@ func (s *VersionSuite) TestVersionSliceStringFormating() {
 	for i, v := range versions {
 		ver, err := CreateMongoDBVersion(v)
 		s.NoError(err)
+		s.Require().NotNil(v)
 		slice[i] = ver
 	}
 
@@ -297,8 +308,9 @@ func (s *VersionSuite) TestParsingIdentifiesRCForRCs() {
 
 	for version, rcNumber := range cases {
 		v, err := CreateMongoDBVersion(version)
-		s.Require().NoError(err)
-		s.Equal(v.RcNumber(), rcNumber)
+		s.NoError(err)
+		s.Require().NotNil(v)
+		s.Equal(v.RCNumber(), rcNumber)
 	}
 
 }
@@ -312,7 +324,8 @@ func (s *VersionSuite) TestRCNumberIsLessThanZeroForNonRCs() {
 	for _, version := range cases {
 		v, err := CreateMongoDBVersion(version)
 		s.NoError(err)
-		s.True(v.RcNumber() < 0)
+		s.Require().NotNil(v)
+		s.True(v.RCNumber() < 0)
 	}
 }
 
@@ -322,6 +335,7 @@ func (s *VersionSuite) TestVersionConversionProducesExpectedVersionObjectsWithou
 	// should convert a string to a version object.
 	vString, err := ConvertVersion(expectedVersion)
 	s.NoError(err)
+	s.Require().NotNil(vString)
 	s.Equal(vString.String(), expectedVersion)
 
 	// pass a pointer to a version object the converter
@@ -332,14 +346,16 @@ func (s *VersionSuite) TestVersionConversionProducesExpectedVersionObjectsWithou
 	// pass a legacy version object itself rather than a ref.
 	vVersionLegacy, ok := vVersionPointer.(*LegacyMongoDBVersion)
 	s.True(ok)
-	s.NotNil(vVersionLegacy)
+	s.Require().NotNil(vVersionLegacy)
 	vVersionObj, err := ConvertVersion(*vVersionLegacy)
 	s.NoError(err)
+	s.Require().NotNil(vVersionObj)
 	s.Equal(vVersionObj.String(), expectedVersion)
 
 	// try a smevar.Version object
 	vSemVar, err := ConvertVersion(vVersionObj.Parsed())
 	s.NoError(err)
+	s.Require().NotNil(vSemVar)
 	s.Equal(vSemVar.String(), expectedVersion)
 }
 
@@ -369,6 +385,7 @@ func (s *VersionSuite) TestLessThanComparator() {
 	for version, expectedValue := range cases {
 		v, err := ConvertVersion(version)
 		s.NoError(err)
+		s.Require().NotNil(v)
 
 		if expectedValue {
 			s.True(v.IsLessThan(s.baseVersion))
@@ -400,6 +417,7 @@ func (s *VersionSuite) TestLessThanOrEqualToComparator() {
 	for version, expectedValue := range cases {
 		v, err := ConvertVersion(version)
 		s.NoError(err)
+		s.Require().NotNil(v)
 
 		if expectedValue {
 			s.True(v.IsLessThanOrEqualTo(s.baseVersion))
@@ -434,6 +452,7 @@ func (s *VersionSuite) TestGreaterThanComparator() {
 	for version, expectedValue := range cases {
 		v, err := ConvertVersion(version)
 		s.NoError(err)
+		s.Require().NotNil(v)
 
 		if expectedValue {
 			s.True(v.IsGreaterThan(s.baseVersion))
@@ -464,6 +483,7 @@ func (s *VersionSuite) TestGreaterThanOrEqualToComparator() {
 	for version, expectedValue := range cases {
 		v, err := ConvertVersion(version)
 		s.NoError(err)
+		s.Require().NotNil(v)
 
 		if expectedValue {
 			s.True(v.IsGreaterThanOrEqualTo(s.baseVersion))
@@ -494,6 +514,7 @@ func (s *VersionSuite) TestVersionEqualityOperators() {
 	for version, isEqual := range cases {
 		v, err := ConvertVersion(version)
 		s.NoError(err)
+		s.Require().NotNil(v)
 
 		if isEqual {
 			s.True(v.IsEqualTo(s.baseVersion))


### PR DESCRIPTION
Similar to how Kim broke it up, this ticket is to define an interface for MongoDBVersion and ensure that LegacyMongoDBVersion implements this interface. I will implement NewMongoDBVersion in the next ticket.

This passes all tests with `make test`. It appears I don't have write access for this repo though if someone could give me that power 💪 