### PR TITLE
EVG-12795 update feed to consider new versioning scheme

### DIFF
--- a/catalog.go
+++ b/catalog.go
@@ -151,7 +151,7 @@ func (c *BuildCatalog) String() string {
 // parameters specified does not exist in the cache.
 func (c *BuildCatalog) Get(version, edition, target, arch string, debug bool) (string, error) {
 	if strings.Contains(version, "current") {
-		v, err := c.feed.GetStableRelease(version)
+		v, err := c.feed.GetLatestRelease(version)
 		if err != nil {
 			return "", errors.Wrapf(err,
 				"could not determine current stable release for %s series", version)

--- a/feed.go
+++ b/feed.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -152,21 +151,16 @@ func (feed *ArtifactsFeed) GetLatestArchive(series string, options BuildOptions)
 		return "", errors.Wrapf(err, "problem fetching download information for series '%s'", series)
 	}
 
-	// if it's a dev version: then the branch name is in the file
-	// name, and we just take the latest from master
-	seriesNum, err := strconv.Atoi(string(series[2]))
+	isDev, err := version.IsDevelopment()
 	if err != nil {
-		// this should be unreachable, because invalid
-		// versions won't have yielded results from the feed
-		// op
-		return "", errors.Wrapf(err, "version specification is invalid")
+		return "", errors.Wrap(err, "problem determining version type")
 	}
 
-	if seriesNum%2 == 1 {
+	// If it's a dev version, the branch name is in the file name, and we just take the latest from master.
+	// Otherwise we just replace the version with the word latest.
+	if isDev {
 		return strings.Replace(dl.Archive.URL, version.Version, "latest", -1), nil
 	}
-
-	// if it's a stable version we just replace the version with the word latest.
 	return strings.Replace(dl.Archive.URL, version.Version, "v"+series+"-latest", -1), nil
 }
 
@@ -175,7 +169,7 @@ func (feed *ArtifactsFeed) GetCurrentArchive(series string, options BuildOptions
 	feed.mutex.RLock()
 	defer feed.mutex.RUnlock()
 
-	version, err := feed.GetStableRelease(series)
+	version, err := feed.GetLatestRelease(series)
 	if err != nil {
 		return "", errors.Wrap(err, "could not find version for: "+series)
 	}
@@ -189,8 +183,8 @@ func (feed *ArtifactsFeed) GetCurrentArchive(series string, options BuildOptions
 
 }
 
-// GetStableRelease returns the latest official release for a specific series.
-func (feed *ArtifactsFeed) GetStableRelease(series string) (*ArtifactVersion, error) {
+// GetLatestRelease returns the latest official release for a specific series.
+func (feed *ArtifactsFeed) GetLatestRelease(series string) (*ArtifactVersion, error) {
 	series = coerceSeries(series)
 
 	if series == "2.4" {
@@ -202,6 +196,7 @@ func (feed *ArtifactsFeed) GetStableRelease(series string) (*ArtifactVersion, er
 	}
 
 	for _, version := range feed.Versions {
+		// Will current be accurate for the new versioning scheme?
 		if version.Current && strings.HasPrefix(version.Version, series) {
 			return version, nil
 		}

--- a/feed.go
+++ b/feed.go
@@ -157,7 +157,7 @@ func (feed *ArtifactsFeed) GetLatestArchive(series string, options BuildOptions)
 	}
 
 	// If it's a development series, we just replace the version with the word latest.
-	// Otherwise the branch name is in the file name, and we take the latest from master.
+	// Otherwise the branch name is in the file name, and we take the latest from the series release.
 	if isDev {
 		return strings.Replace(dl.Archive.URL, version.Version, "latest", -1), nil
 	}

--- a/feed.go
+++ b/feed.go
@@ -151,13 +151,13 @@ func (feed *ArtifactsFeed) GetLatestArchive(series string, options BuildOptions)
 		return "", errors.Wrapf(err, "problem fetching download information for series '%s'", series)
 	}
 
-	isDev, err := version.IsDevelopment()
+	isDev, err := version.isNightlyOrContinuous()
 	if err != nil {
 		return "", errors.Wrap(err, "problem determining version type")
 	}
 
-	// If it's a dev version, the branch name is in the file name, and we just take the latest from master.
-	// Otherwise we just replace the version with the word latest.
+	// If it's nightly or continuous, we just replace the version with the word latest.
+	// Otherwise the branch name is in the file name, and we just take the latest from master.
 	if isDev {
 		return strings.Replace(dl.Archive.URL, version.Version, "latest", -1), nil
 	}

--- a/feed.go
+++ b/feed.go
@@ -151,13 +151,13 @@ func (feed *ArtifactsFeed) GetLatestArchive(series string, options BuildOptions)
 		return "", errors.Wrapf(err, "problem fetching download information for series '%s'", series)
 	}
 
-	isDev, err := version.isNightlyOrContinuous()
+	isDev, err := version.isDevelopmentSeries()
 	if err != nil {
 		return "", errors.Wrap(err, "problem determining version type")
 	}
 
-	// If it's nightly or continuous, we just replace the version with the word latest.
-	// Otherwise the branch name is in the file name, and we just take the latest from master.
+	// If it's a development series, we just replace the version with the word latest.
+	// Otherwise the branch name is in the file name, and we take the latest from master.
 	if isDev {
 		return strings.Replace(dl.Archive.URL, version.Version, "latest", -1), nil
 	}
@@ -196,7 +196,6 @@ func (feed *ArtifactsFeed) GetLatestRelease(series string) (*ArtifactVersion, er
 	}
 
 	for _, version := range feed.Versions {
-		// Will current be accurate for the new versioning scheme?
 		if version.Current && strings.HasPrefix(version.Version, series) {
 			return version, nil
 		}

--- a/version.go
+++ b/version.go
@@ -35,14 +35,14 @@ func (version *ArtifactVersion) refresh() {
 	}
 }
 
-// IsStableVersion returns true if the version indicates an official release.
-func (version *ArtifactVersion) IsDevelopment() (bool, error) {
+// isNightlyOrContinuous returns true if the version doesn't indicate an official release.
+func (version *ArtifactVersion) isNightlyOrContinuous() (bool, error) {
 	parsedVersion, err := CreateMongoDBVersion(version.Version)
 	if err != nil {
 		return false, errors.Wrap(err, "could not parse version")
 	}
 	// handle legacy and modern versioning schemes
-	return !parsedVersion.IsStableSeries() && !parsedVersion.IsLTS(), nil
+	return !parsedVersion.IsStableSeries() || parsedVersion.IsContinuous(), nil
 }
 
 // GetDownload returns a matching ArtifactDownload object

--- a/version.go
+++ b/version.go
@@ -35,14 +35,12 @@ func (version *ArtifactVersion) refresh() {
 	}
 }
 
-// isNightlyOrContinuous returns true if the version doesn't indicate an official release.
-func (version *ArtifactVersion) isNightlyOrContinuous() (bool, error) {
+func (version *ArtifactVersion) isDevelopmentSeries() (bool, error) {
 	parsedVersion, err := CreateMongoDBVersion(version.Version)
 	if err != nil {
 		return false, errors.Wrap(err, "could not parse version")
 	}
-	// handle legacy and modern versioning schemes
-	return !parsedVersion.IsStableSeries() || parsedVersion.IsContinuous(), nil
+	return parsedVersion.IsDevelopmentSeries(), nil
 }
 
 // GetDownload returns a matching ArtifactDownload object

--- a/version.go
+++ b/version.go
@@ -35,6 +35,16 @@ func (version *ArtifactVersion) refresh() {
 	}
 }
 
+// IsStableVersion returns true if the version indicates an official release.
+func (version *ArtifactVersion) IsDevelopment() (bool, error) {
+	parsedVersion, err := CreateMongoDBVersion(version.Version)
+	if err != nil {
+		return false, errors.Wrap(err, "could not parse version")
+	}
+	// handle legacy and modern versioning schemes
+	return !parsedVersion.IsStableSeries() && !parsedVersion.IsLTS(), nil
+}
+
 // GetDownload returns a matching ArtifactDownload object
 // given a BuildOptions object.
 func (version *ArtifactVersion) GetDownload(key BuildOptions) (ArtifactDownload, error) {


### PR DESCRIPTION
I'm not sure how much of this relies on mr being updated, like I don't know if current is something to rely on anymore? Other than these instances I don't think anything else here relies on versioning.