### PR TITLE
EVG-12799: Fix semantics of IsDevelopmentBuild for NewMongoDBVersion

### DIFF
--- a/versions.go
+++ b/versions.go
@@ -167,7 +167,12 @@ func createNewMongoDBVersion(parsedVersion LegacyMongoDBVersion) (*NewMongoDBVer
 			return nil, errors.Wrapf(err, "couldn't parse development release number")
 		}
 	}
-	return v, err
+
+	if v.isDev {
+		return nil, errors.New("development builds are not allowed in the new versioning scheme")
+	}
+
+	return v, nil
 }
 
 // createLegacyMongoDBVersion takes a string representing a MongoDB version and

--- a/versions.go
+++ b/versions.go
@@ -13,9 +13,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	"github.com/blang/semver"
+	"github.com/pkg/errors"
 )
 
 const (

--- a/versions.go
+++ b/versions.go
@@ -9,16 +9,17 @@ package bond
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/pkg/errors"
 
 	"github.com/blang/semver"
 )
 
 const (
-	endOfLegacy = "4.5.0-alpha0"
+	endOfLegacy   = "4.5.0-alpha0"
 	devReleaseTag = "alpha"
 )
 
@@ -66,7 +67,6 @@ type MongoDBVersion interface {
 	IsGreaterThanOrEqualTo(version MongoDBVersion) bool
 	IsEqualTo(version MongoDBVersion) bool
 	IsNotEqualTo(version MongoDBVersion) bool
-
 }
 
 // LegacyMongoDBVersion is a structure representing a version identifier for legacy versions of
@@ -85,9 +85,9 @@ type LegacyMongoDBVersion struct {
 // MongoDB, which implements the MongoDBVersion.
 type NewMongoDBVersion struct {
 	LegacyMongoDBVersion // note not all fields are applicable to NewMongoDBVersion
-	isDevRelease bool
-	devReleaseNumber int
-	quarter string
+	isDevRelease         bool
+	devReleaseNumber     int
+	quarter              string
 }
 
 // IsStableSeries is not applicable to new versions, so always return false.
@@ -161,6 +161,7 @@ func createNewMongoDBVersion(parsedVersion LegacyMongoDBVersion) (*NewMongoDBVer
 	}
 	v.quarter = v.String()[:3]
 	if strings.Contains(v.tag, devReleaseTag) {
+		v.isDev = false
 		v.isDevRelease = true
 		v.devReleaseNumber, err = strconv.Atoi(v.tag[len(devReleaseTag):])
 		if err != nil {

--- a/versions_test.go
+++ b/versions_test.go
@@ -224,6 +224,32 @@ func (s *VersionSuite) TestVersionCanIdentifyReleases() {
 	}
 }
 
+func (s *VersionSuite) TestDevelopmentBuildsOnlyAllowedInLegacyVersion() {
+	legacyBuilds := []string{
+		"3.1.5-68-gdd3f158",
+		"3.8.5-23-gffd4a182",
+		"3.2.1-",
+		"2.6.1-pre-",
+	}
+	for _, version := range legacyBuilds {
+		v, err := CreateMongoDBVersion(version)
+		s.NoError(err)
+		s.Require().NotNil(v)
+		s.True(v.IsDevelopmentBuild())
+	}
+
+	newBuilds := []string{
+		"5.1.5-68-gdd3f158",
+		"5.3.5-23-gffd4a182",
+		"5.2.1-",
+		"5.3.1-pre-",
+	}
+	for _, version := range newBuilds {
+		_, err := CreateMongoDBVersion(version)
+		s.Error(err)
+	}
+}
+
 func (s *VersionSuite) TestDistinguishInitialStableVersionRC() {
 	releases := []string{
 		"3.4.0-rc0",
@@ -358,7 +384,6 @@ func (s *VersionSuite) TestIsDevelopmentRelease() {
 		"3.2.7":          false,
 		"3.4.0-alpha12":  false,
 		"4.5.0-alpha4":   true,
-		"5.4.9-":         false,
 		"5.0.0-alpha123": true,
 		"5.0.0-rc12":     false,
 		"5.0.0":          false,
@@ -412,7 +437,6 @@ func (s *VersionSuite) TestIsContinuous() {
 		"3.4.0":        false,
 		"4.4.9":        false,
 		"4.5.0":        true,
-		"4.5.0-":       false,
 		"5.0.0-rc12":   false,
 		"5.0.0":        false,
 		"5.3.9-alpha1": true,

--- a/versions_test.go
+++ b/versions_test.go
@@ -197,6 +197,7 @@ func (s *VersionSuite) TestVersionCanIdentifyReleases() {
 		"5.2.0",
 		"5.3.3",
 		"5.4.0-rc12",
+		"5.0.0-alpha12",
 	}
 
 	for _, version := range releases {
@@ -212,7 +213,6 @@ func (s *VersionSuite) TestVersionCanIdentifyReleases() {
 		"3.8.5-23-gffd4a182",
 		"3.2.1-",
 		"2.6.1-pre-",
-		"5.0.0-alpha12",
 	}
 
 	for _, version := range builds {
@@ -326,7 +326,7 @@ func (s *VersionSuite) TestParsingIdentifiesRCForRCs() {
 		"2.4.0-rc42": 42,
 		"1.8.4-rc1":  1,
 		"4.4.1-rc12": 12,
-		"5.5.0-rc8": 8,
+		"5.5.0-rc8":  8,
 	}
 
 	for version, rcNumber := range cases {
@@ -354,14 +354,14 @@ func (s *VersionSuite) TestRCNumberIsLessThanZeroForNonRCs() {
 
 func (s *VersionSuite) TestIsDevelopmentRelease() {
 	cases := map[string]bool{
-		"1.8.0-rc0": false,
-		"3.2.7": false,
-		"3.4.0-alpha12": false,
-		"4.5.0-alpha4": true,
-		"5.4.9-": false,
+		"1.8.0-rc0":      false,
+		"3.2.7":          false,
+		"3.4.0-alpha12":  false,
+		"4.5.0-alpha4":   true,
+		"5.4.9-":         false,
 		"5.0.0-alpha123": true,
-		"5.0.0-rc12": false,
-		"5.0.0": false,
+		"5.0.0-rc12":     false,
+		"5.0.0":          false,
 	}
 	for v, expectedValue := range cases {
 		version, err := ConvertVersion(v)
@@ -373,13 +373,13 @@ func (s *VersionSuite) TestIsDevelopmentRelease() {
 
 func (s *VersionSuite) TestDevelopmentReleaseNumber() {
 	cases := map[string]int{
-		"3.4.0-alpha12": -1,
-		"4.6.0": -1,
-		"4.5.0-alpha4": 4,
-		"5.4.9-alpha1": 1,
+		"3.4.0-alpha12":  -1,
+		"4.6.0":          -1,
+		"4.5.0-alpha4":   4,
+		"5.4.9-alpha1":   1,
 		"5.0.0-alpha123": 123,
-		"5.0.0-rc12": -1,
-		"5.0.0": -1,
+		"5.0.0-rc12":     -1,
+		"5.0.0":          -1,
 	}
 	for v, expectedValue := range cases {
 		version, err := ConvertVersion(v)
@@ -391,11 +391,11 @@ func (s *VersionSuite) TestDevelopmentReleaseNumber() {
 
 func (s *VersionSuite) TestIsLTS() {
 	cases := map[string]bool{
-		"4.0.0": false,
-		"4.5.0": false,
+		"4.0.0":          false,
+		"4.5.0":          false,
 		"5.0.4-alpha123": false,
-		"5.0.4-rc12": true,
-		"5.0.9": true,
+		"5.0.4-rc12":     true,
+		"5.0.9":          true,
 	}
 	for v, expectedValue := range cases {
 		version, err := ConvertVersion(v)
@@ -407,15 +407,15 @@ func (s *VersionSuite) TestIsLTS() {
 
 func (s *VersionSuite) TestIsContinuous() {
 	cases := map[string]bool{
-		"1.8.0-rc0": false,
-		"3.2.7": false,
-		"3.4.0": false,
-		"4.4.9": false,
-		"4.5.0": true,
-		"4.5.0-": false,
+		"1.8.0-rc0":    false,
+		"3.2.7":        false,
+		"3.4.0":        false,
+		"4.4.9":        false,
+		"4.5.0":        true,
+		"4.5.0-":       false,
 		"5.4.9-alpha1": false,
-		"5.0.0-rc12": false,
-		"5.0.0": false,
+		"5.0.0-rc12":   false,
+		"5.0.0":        false,
 	}
 	for v, expectedValue := range cases {
 		version, err := ConvertVersion(v)

--- a/versions_test.go
+++ b/versions_test.go
@@ -393,7 +393,7 @@ func (s *VersionSuite) TestIsLTS() {
 	cases := map[string]bool{
 		"4.0.0":          false,
 		"4.5.0":          false,
-		"5.0.4-alpha123": false,
+		"5.0.4-alpha123": true,
 		"5.0.4-rc12":     true,
 		"5.0.9":          true,
 	}
@@ -413,9 +413,9 @@ func (s *VersionSuite) TestIsContinuous() {
 		"4.4.9":        false,
 		"4.5.0":        true,
 		"4.5.0-":       false,
-		"5.4.9-alpha1": false,
 		"5.0.0-rc12":   false,
 		"5.0.0":        false,
+		"5.3.9-alpha1": true,
 	}
 	for v, expectedValue := range cases {
 		version, err := ConvertVersion(v)


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-12799

When a new version is created, if it has the dev release tag it will set `isDev` is `false` (since that would be set to `true` in the old versioning scheme) while setting `isDevRelease` is `true`.

Also, when I saved the files a bunch of auto-formatting happened.