### PR TITLE
EVG-12798: add fields for new release feed format

### DIFF
--- a/version.go
+++ b/version.go
@@ -18,7 +18,9 @@ type ArtifactVersion struct {
 
 	ProductionRelease  bool `json:"production_release"`
 	DevelopmentRelease bool `json:"development_release"`
-	Current            bool
+	LTSRelease         bool `json:"lts_release"`
+	ContinuousRelease  bool `json:"continuous_release"`
+	Current            bool `json:"current"`
 
 	table map[BuildOptions]ArtifactDownload
 	mutex sync.RWMutex


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-12798

The LTS/continuous fields won't appear in the feed until a release is done to update the live feed, so we can't test it.

* Add fields for LTS/continuous, which will appear in the full feed.
* Include JSON tags for current.