### PR TITLE
EVG-12946: Use LTS version as notary key name instead of series key

### DIFF
--- a/versions.go
+++ b/versions.go
@@ -119,7 +119,6 @@ func (v *NewMongoDBVersion) Series() string {
 
 // IsLTS returns true if this is the first release of the year.
 func (v *NewMongoDBVersion) IsLTS() bool {
-
 	return v.IsRelease() && v.Parsed().Minor == 0
 }
 

--- a/versions.go
+++ b/versions.go
@@ -177,7 +177,7 @@ func createNewMongoDBVersion(parsedVersion LegacyMongoDBVersion) (*NewMongoDBVer
 	if strings.Contains(v.tag, devReleaseTag) {
 		v.isDev = false
 		v.isDevRelease = true
-		if len(v.tag) != len(devReleaseTag) {
+		if len(v.tag) > len(devReleaseTag) {
 			v.devReleaseNumber, err = strconv.Atoi(v.tag[len(devReleaseTag):])
 			if err != nil {
 				return nil, errors.Wrapf(err, "couldn't parse development release number")

--- a/versions.go
+++ b/versions.go
@@ -162,9 +162,11 @@ func createNewMongoDBVersion(parsedVersion LegacyMongoDBVersion) (*NewMongoDBVer
 	if strings.Contains(v.tag, devReleaseTag) {
 		v.isDev = false
 		v.isDevRelease = true
-		v.devReleaseNumber, err = strconv.Atoi(v.tag[len(devReleaseTag):])
-		if err != nil {
-			return nil, errors.Wrapf(err, "couldn't parse development release number")
+		if len(v.tag) != len(devReleaseTag) {
+			v.devReleaseNumber, err = strconv.Atoi(v.tag[len(devReleaseTag):])
+			if err != nil {
+				return nil, errors.Wrapf(err, "couldn't parse development release number")
+			}
 		}
 	}
 

--- a/versions_test.go
+++ b/versions_test.go
@@ -434,6 +434,25 @@ func (s *VersionSuite) TestIsLTS() {
 	}
 }
 
+func (s *VersionSuite) TestLTS() {
+	cases := map[string]string{
+		"4.0.0":          "",
+		"4.5.0":          "",
+		"4.8.0":          "",
+		"5.0.0":          "5.0",
+		"5.0.4-alpha123": 5.0,
+		"5.0.9":          true,
+		"5.3.8":          "5.0",
+		"6.1.1":          "6.0",
+	}
+	for v, expectedValue := range cases {
+		version, err := ConvertVersion(v)
+		s.NoError(err)
+		s.Require().NotNil(version)
+		s.Equal(expectedValue, version.LTS(), v)
+	}
+}
+
 func (s *VersionSuite) TestIsContinuous() {
 	cases := map[string]bool{
 		"1.8.0-rc0":    false,

--- a/versions_test.go
+++ b/versions_test.go
@@ -43,6 +43,7 @@ func (s *VersionSuite) TestValidVersionsParseWithoutErrors() {
 		"3.0.1-pre-",
 		"4.7.7",
 		"5.0.0-rc12",
+		"5.1.2-alpha",
 		"5.1.2-alpha14",
 	}
 	for _, version := range versions {
@@ -197,6 +198,7 @@ func (s *VersionSuite) TestVersionCanIdentifyReleases() {
 		"5.2.0",
 		"5.3.3",
 		"5.4.0-rc12",
+		"5.0.0-alpha",
 		"5.0.0-alpha12",
 	}
 
@@ -383,6 +385,7 @@ func (s *VersionSuite) TestIsDevelopmentRelease() {
 		"1.8.0-rc0":      false,
 		"3.2.7":          false,
 		"3.4.0-alpha12":  false,
+		"4.5.0-alpha":    true,
 		"4.5.0-alpha4":   true,
 		"5.0.0-alpha123": true,
 		"5.0.0-rc12":     false,
@@ -400,6 +403,7 @@ func (s *VersionSuite) TestDevelopmentReleaseNumber() {
 	cases := map[string]int{
 		"3.4.0-alpha12":  -1,
 		"4.6.0":          -1,
+		"4.5.0-alpha":    0,
 		"4.5.0-alpha4":   4,
 		"5.4.9-alpha1":   1,
 		"5.0.0-alpha123": 123,


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-12947

- Also added a method to the `MongoDBVersion` called `LTS` that will return the most recent LTS series (this is useful for the notary key no longer being the series but the LTS series).