### PR TITLE
EVG-13089: fix errors in bond

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,5 @@ linters:
     - goimports
     - govet
     - ineffassign
-    - interfacer
     - misspell
     - unconvert

--- a/versions.go
+++ b/versions.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	endOfLegacy   = "4.5.0-alpha0"
+	endOfLegacy   = "4.5.0-alpha"
 	firstLTS      = "5.0.0"
 	devReleaseTag = "alpha"
 )
@@ -154,11 +154,15 @@ func (v *NewMongoDBVersion) DevelopmentReleaseNumber() int {
 // If the parsed version is before 4.5.0, then we use the legacy structure.
 // Otherwise, we use the modern versioning scheme.
 func CreateMongoDBVersion(version string) (MongoDBVersion, error) {
-	endOfLegacyVersion, _ := semver.Parse(endOfLegacy)
+	endOfLegacyVersion, err := semver.Parse(endOfLegacy)
+	if err != nil {
+		return nil, errors.Wrapf(err, "parsing end of legacy version")
+	}
 	v, err := createLegacyMongoDBVersion(version)
 	if err != nil {
 		return nil, errors.Wrapf(err, "creating initial version")
 	}
+
 	if v.Parsed().LT(endOfLegacyVersion) {
 		return v, nil
 	}

--- a/versions_test.go
+++ b/versions_test.go
@@ -387,6 +387,7 @@ func (s *VersionSuite) TestIsDevelopmentRelease() {
 		"3.4.0-alpha12":  false,
 		"4.5.0-alpha":    true,
 		"4.5.0-alpha4":   true,
+		"4.6.0-alpha":    true,
 		"5.0.0-alpha123": true,
 		"5.0.0-rc12":     false,
 		"5.0.0":          false,
@@ -402,9 +403,10 @@ func (s *VersionSuite) TestIsDevelopmentRelease() {
 func (s *VersionSuite) TestDevelopmentReleaseNumber() {
 	cases := map[string]int{
 		"3.4.0-alpha12":  -1,
-		"4.6.0":          -1,
-		"4.5.0-alpha":    0,
+		"4.5.0-alpha":    -1,
 		"4.5.0-alpha4":   4,
+		"4.6.0":          -1,
+		"4.6.0-alpha":    -1,
 		"5.4.9-alpha1":   1,
 		"5.0.0-alpha123": 123,
 		"5.0.0-rc12":     -1,
@@ -440,8 +442,8 @@ func (s *VersionSuite) TestLTS() {
 		"4.5.0":          "",
 		"4.8.0":          "",
 		"5.0.0":          "5.0",
-		"5.0.4-alpha123": 5.0,
-		"5.0.9":          true,
+		"5.0.4-alpha123": "5.0",
+		"5.0.9":          "5.0",
 		"5.3.8":          "5.0",
 		"6.1.1":          "6.0",
 	}


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13089

* Fix tests with syntax errors.
* Deal with 4.5.0-alpha being considered a lower semantic version than 4.5.0-alpha0 by semver.