### PR TITLE
EVG-13174: Fix parsing dev releases with git describe

### DIFF
--- a/versions.go
+++ b/versions.go
@@ -181,8 +181,13 @@ func createNewMongoDBVersion(parsedVersion LegacyMongoDBVersion) (*NewMongoDBVer
 	if strings.Contains(v.tag, devReleaseTag) {
 		v.isDev = false
 		v.isDevRelease = true
-		if len(v.tag) > len(devReleaseTag) {
-			v.devReleaseNumber, err = strconv.Atoi(v.tag[len(devReleaseTag):])
+		// Releases triggered by the waterfall use the git describe of
+		// the commit, we need to remove that before attempting to get
+		// the dev release number.
+		split := strings.Split(v.tag, "-")
+		if len(split) > 0 && len(split[0]) > len(devReleaseTag) {
+			fmt.Println(split)
+			v.devReleaseNumber, err = strconv.Atoi(split[0][len(devReleaseTag):])
 			if err != nil {
 				return nil, errors.Wrapf(err, "couldn't parse development release number")
 			}

--- a/versions.go
+++ b/versions.go
@@ -186,7 +186,6 @@ func createNewMongoDBVersion(parsedVersion LegacyMongoDBVersion) (*NewMongoDBVer
 		// the dev release number.
 		split := strings.Split(v.tag, "-")
 		if len(split) > 0 && len(split[0]) > len(devReleaseTag) {
-			fmt.Println(split)
 			v.devReleaseNumber, err = strconv.Atoi(split[0][len(devReleaseTag):])
 			if err != nil {
 				return nil, errors.Wrapf(err, "couldn't parse development release number")

--- a/versions_test.go
+++ b/versions_test.go
@@ -42,6 +42,7 @@ func (s *VersionSuite) TestValidVersionsParseWithoutErrors() {
 		"3.0.2-",
 		"3.0.1-pre-",
 		"4.7.7",
+		"4.8.0-alpha-26-g610cb6a",
 		"5.0.0-rc12",
 		"5.1.2-alpha",
 		"5.1.2-alpha14",


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13174

This ticket just splits the dev tag by "-" to get rid of any git describe info that is attached to the versioning (we don't care about it).

