### PR TITLE
EVG-14482, EVG-14502: upgrade go version and linter

### DIFF
--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -28,7 +28,7 @@ functions:
       working_dir: gopath/src/github.com/evergreen-ci/bond
       binary: make
       args: ["${target}"]
-      add_expansions_to_env: true
+      include_expansions_in_env: ["DISABLE_COVERAGE", "GO_BIN_PATH", "GOROOT", "RACE_DETECTOR"]
       env:
         GOPATH: ${workdir}/gopath
   parse-results:
@@ -77,7 +77,7 @@ task_groups:
       - func: run-make
         vars: { target: "docker-setup" }
         variants:
-          - ubuntu1604
+          - ubuntu
     setup_task:
       - func: run-make
         vars: { target: "clean-results" }
@@ -85,7 +85,7 @@ task_groups:
       - func: run-make
         vars: { target: "docker-cleanup" }
         variants:
-          - ubuntu1604
+          - ubuntu
       - func: parse-results
 
 #######################################
@@ -96,10 +96,9 @@ buildvariants:
     display_name: Race Detector (Arch Linux)
     expansions:
       DISABLE_COVERAGE: true
-      GOROOT: /opt/golang/go1.13
-      GO_BIN_PATH: /opt/golang/go1.13/bin/go
+      GOROOT: /opt/golang/go1.16
+      GO_BIN_PATH: /opt/golang/go1.16/bin/go
       RACE_DETECTOR: true
-      SKIP_DOCKER_TESTS: true
     run_on:
       - archlinux-new-small
       - archlinux-new-large
@@ -110,23 +109,23 @@ buildvariants:
     display_name: Lint (Arch Linux)
     expansions:
       DISABLE_COVERAGE: true
-      GOROOT: /opt/golang/go1.13
-      GO_BIN_PATH: /opt/golang/go1.13/bin/go
+      GOROOT: /opt/golang/go1.16
+      GO_BIN_PATH: /opt/golang/go1.16/bin/go
     run_on:
       - archlinux-new-small
       - archlinux-new-large
     tasks: 
       - name: "lintGroup"
 
-  - name: ubuntu1604
-    display_name: Ubuntu 16.04
+  - name: ubuntu
+    display_name: Ubuntu 18.04
     expansions:
       DISABLE_COVERAGE: true
-      GOROOT: /opt/golang/go1.9
-      GO_BIN_PATH: /opt/golang/go1.9/bin/go
+      GOROOT: /opt/golang/go1.16
+      GO_BIN_PATH: /opt/golang/go1.16/bin/go
     run_on:
-      - ubuntu1604-small
-      - ubuntu1604-large
+      - ubuntu1804-small
+      - ubuntu1804-large
     tasks:
       - name: "testGroup"
 
@@ -134,8 +133,8 @@ buildvariants:
     display_name: macOS
     expansions:
       DISABLE_COVERAGE: true
-      GOROOT: /opt/golang/go1.11
-      GO_BIN_PATH: /opt/golang/go1.11/bin/go
+      GOROOT: /opt/golang/go1.16
+      GO_BIN_PATH: /opt/golang/go1.16/bin/go
     run_on:
       - macos-1014
     tasks:
@@ -148,7 +147,7 @@ buildvariants:
       - windows-64-vs2017-large
     expansions:
       DISABLE_COVERAGE: true
-      GOROOT: C:/golang/go1.11
-      GO_BIN_PATH: /cygdrive/c/golang/go1.11/bin/go
+      GOROOT: C:/golang/go1.16
+      GO_BIN_PATH: /cygdrive/c/golang/go1.16/bin/go
     tasks:
       - name: "testGroup"

--- a/makefile
+++ b/makefile
@@ -24,6 +24,7 @@ endif
 export GOPATH := $(gopath)
 export GOCACHE := $(gocache)
 export GOROOT := $(goroot)
+export GO111MODULE := off
 # end environment setup
 
 
@@ -34,7 +35,7 @@ $(shell mkdir -p $(buildDir))
 # start linting configuration
 lintDeps := $(buildDir)/golangci-lint $(buildDir)/run-linter
 $(buildDir)/golangci-lint:
-	@curl --retry 10 --retry-max-time 60 -sSfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(buildDir) v1.30.0 >/dev/null 2>&1
+	@curl --retry 10 --retry-max-time 60 -sSfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(buildDir) v1.40.0 >/dev/null 2>&1
 $(buildDir)/run-linter:cmd/run-linter/run-linter.go $(buildDir)/golangci-lint
 	$(gobin) build -o $@ $<
 # end linting configuration


### PR DESCRIPTION
Jira:
https://jira.mongodb.org/browse/EVG-14482
https://jira.mongodb.org/browse/EVG-14502

* Upgrade go to 1.16.
* Upgrade golangci-lint to 1.40.
* Upgrade Ubuntu to 18.04.