### PR TITLE
EVG-15479, EVG-15495: remove GO_BIN_PATH and fix linter PATH

### DIFF
--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -28,7 +28,7 @@ functions:
       working_dir: gopath/src/github.com/evergreen-ci/bond
       binary: make
       args: ["${target}"]
-      include_expansions_in_env: ["DISABLE_COVERAGE", "GO_BIN_PATH", "GOROOT", "RACE_DETECTOR"]
+      include_expansions_in_env: ["DISABLE_COVERAGE", "GOROOT", "RACE_DETECTOR"]
       env:
         GOPATH: ${workdir}/gopath
   parse-results:
@@ -97,7 +97,6 @@ buildvariants:
     expansions:
       DISABLE_COVERAGE: true
       GOROOT: /opt/golang/go1.16
-      GO_BIN_PATH: /opt/golang/go1.16/bin/go
       RACE_DETECTOR: true
     run_on:
       - archlinux-new-small
@@ -110,7 +109,6 @@ buildvariants:
     expansions:
       DISABLE_COVERAGE: true
       GOROOT: /opt/golang/go1.16
-      GO_BIN_PATH: /opt/golang/go1.16/bin/go
     run_on:
       - archlinux-new-small
       - archlinux-new-large
@@ -122,7 +120,6 @@ buildvariants:
     expansions:
       DISABLE_COVERAGE: true
       GOROOT: /opt/golang/go1.16
-      GO_BIN_PATH: /opt/golang/go1.16/bin/go
     run_on:
       - ubuntu1804-small
       - ubuntu1804-large
@@ -134,7 +131,6 @@ buildvariants:
     expansions:
       DISABLE_COVERAGE: true
       GOROOT: /opt/golang/go1.16
-      GO_BIN_PATH: /opt/golang/go1.16/bin/go
     run_on:
       - macos-1014
     tasks:
@@ -148,6 +144,5 @@ buildvariants:
     expansions:
       DISABLE_COVERAGE: true
       GOROOT: C:/golang/go1.16
-      GO_BIN_PATH: /cygdrive/c/golang/go1.16/bin/go
     tasks:
       - name: "testGroup"

--- a/makefile
+++ b/makefile
@@ -2,35 +2,32 @@
 name := bond
 buildDir := build
 packages := $(name) recall
+srcFiles := makefile $(shell find . -name "*.go" -not -path "./$(buildDir)/*" -not -name "*_test.go")
 orgPath := github.com/evergreen-ci
 projectPath := $(orgPath)/$(name)
 # end project configuration
 
-
 # start environment setup
-gobin := $(GO_BIN_PATH)
-ifeq ($(gobin),)
 gobin := go
-endif
-gopath := $(GOPATH)
-gocache := $(abspath $(buildDir)/.cache)
-goroot := $(GOROOT)
-ifeq ($(OS),Windows_NT)
-gocache := $(shell cygpath -m $(gocache))
-gopath := $(shell cygpath -m $(gopath))
-goroot := $(shell cygpath -m $(goroot))
+ifneq (,$(GOROOT))
+gobin := $(GOROOT)/bin/go
 endif
 
-export GOPATH := $(gopath)
-export GOCACHE := $(gocache)
-export GOROOT := $(goroot)
+ifeq ($(OS),Windows_NT)
+gobin := $(shell cygpath $(gobin))
+export GOCACHE := $(shell cygpath -m $(abspath $(buildDir)/.cache))
+export GOLANGCI_LINT_CACHE := $(shell cygpath -m $(abspath $(buildDir)/.lint-cache))
+export GOPATH := $(shell cygpath -m $(GOPATH))
+export GOROOT := $(shell cygpath -m $(GOROOT))
+endif
+
 export GO111MODULE := off
 # end environment setup
-
 
 # Ensure the build directory exists, since most targets require it.
 $(shell mkdir -p $(buildDir))
 
+.DEFAULT_GOAL := compile
 
 # start linting configuration
 lintDeps := $(buildDir)/golangci-lint $(buildDir)/run-linter
@@ -40,39 +37,24 @@ $(buildDir)/run-linter:cmd/run-linter/run-linter.go $(buildDir)/golangci-lint
 	$(gobin) build -o $@ $<
 # end linting configuration
 
-
-######################################################################
-##
-## Everything below this point is generic, and does not contain
-## project specific configuration. (with one noted case in the "build"
-## target for library-only projects)
-##
-######################################################################
-
-
-# start dependency installation tools
-#   implementation details for being able to lazily install dependencies
-srcFiles := makefile $(shell find . -name "*.go" -not -path "./$(buildDir)/*" -not -name "*_test.go")
+# start output files
 testOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).test)
 lintOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).lint)
 coverageOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).coverage)
 coverageHtmlOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).coverage.html)
-# end dependency installation tools
-
-
-# userfacing targets for basic build and development operations
-compile $(buildDir):$(srcFiles)
-	$(gobin) build $(subst $(name),,$(subst -,/,$(foreach pkg,$(packages),./$(pkg))))
-test:$(testOutput)
-lint:$(lintOutput)
-coverage:$(coverageOutput)
-coverage-html:$(coverageHtmlOutput)
-phony := lint build test coverage coverage-html
 .PRECIOUS: $(testOutput) $(coverageOutput) $(lintOutput) $(coverageHtmlOutput)
-# end front-ends
+# end output files
 
+# start basic development targets
+compile: $(srcFiles)
+	$(gobin) build $(subst $(name),,$(subst -,/,$(foreach pkg,$(packages),./$(pkg))))
+test: $(testOutput)
+lint: $(lintOutput)
+coverage: $(coverageOutput)
+coverage-html: $(coverageHtmlOutput)
+phony := compile lint build test coverage coverage-html
 
-# convenience targets for runing tests and coverage tasks on a
+# start convenience targets for running tests and coverage tasks on a
 # specific package.
 test-%:$(buildDir)/output.%.test
 	@grep -s -q -e "^PASS" $<
@@ -82,13 +64,10 @@ html-coverage-%:$(buildDir)/output.%.coverage $(buildDir)/output.%.coverage.html
 	@grep -s -q -e "^PASS" $(subst coverage,test,$<)
 lint-%:$(buildDir)/output.%.lint
 	@grep -v -s -q "^--- FAIL" $<
-# end convienence targets
-
+# end convenience targets
+# end basic development targets
 
 # start test and coverage artifacts
-#    tests have compile and runtime deps. This varable has everything
-#    that the tests actually need to run. (The "build" target is
-#    intentional and makes these targets rerun as expected.)
 testArgs := -v -timeout=15m
 ifeq (,$(DISABLE_COVERAGE))
 	testArgs += -cover
@@ -102,21 +81,22 @@ endif
 ifneq (,$(RUN_TEST))
 	testArgs += -run='$(RUN_TEST)'
 endif
-#  targets to run the tests and report the output
 $(buildDir)/output.%.test: .FORCE
 	$(gobin) test $(testArgs) ./$(if $(subst $(name),,$*),$(subst -,/,$*),) | tee $@
-#  targets to generate gotest output from the linter.
-# We have to handle the PATH specially for CI, because if the PATH has a different version of Go in it, it'll break.
-$(buildDir)/output.%.lint:$(buildDir)/run-linter .FORCE
-	@$(if $(GO_BIN_PATH), PATH="$(shell dirname $(GO_BIN_PATH)):$(PATH)") ./$< --output=$@ --lintBin=$(buildDir)/golangci-lint --packages='$*'
-#  targets to process and generate coverage reports
 $(buildDir)/output.%.coverage:$(buildDir)/output.%.test .FORCE
-	$(gobin) test -covermode=count -coverprofile $@ | tee $(subst coverage,test,$@)
+	$(gobin) test -covermode=count -coverprofile $@ | tee $(buildDir)/output.$*.test
 	@-[ -f $@ ] && $(gobin) tool cover -func=$@ | sed 's%$(projectPath)/%%' | column -t
 $(buildDir)/output.%.coverage.html:$(buildDir)/output.%.coverage
 	$(gobin) tool cover -html=$< -o $@
-# end test and coverage artifacts
 
+ifneq (go,$(gobin))
+# We have to handle the PATH specially for linting in CI, because if the PATH has a different version of the Go
+# binary in it, the linter won't work properly.
+lintEnvVars := PATH="$(shell dirname $(gobin)):$(PATH)"
+endif
+$(buildDir)/output.%.lint: $(buildDir)/run-linter .FORCE
+	@$(lintEnvVars) ./$< --output=$@ --lintBin=$(buildDir)/golangci-lint --packages='$*'
+# end test and coverage artifacts
 
 # start vendoring configuration
 vendor-clean:
@@ -129,17 +109,17 @@ vendor-clean:
 	rm -rf vendor/github.com/mongodb/grip/vendor/github.com/pkg/
 	find vendor/ -name "*.gif" -o -name "*.gz" -o -name "*.png" -o -name "*.ico" -o -name "*.dat" -o -name "*testdata" | xargs rm -fr
 phony += vendor-clean
-# end vendoring tooling configuration
+# end vendoring configuration
 
 
-# clean and other utility targets
+# start cleanup targets
 clean:
-	rm -rf $(lintDeps)
+	rm -rf $(buildDir)
 clean-results:
 	rm -rf $(buildDir)/output.*
-phony += clean
-# end dependency targets
+phony += clean clean-results
+# end cleanup targets
 
 # configure phony targets
 .FORCE:
-.PHONY:$(phony)
+.PHONY: $(phony) .FORCE


### PR DESCRIPTION
Jira:
https://jira.mongodb.org/browse/EVG-15479
https://jira.mongodb.org/browse/EVG-15495

* Remove GO_BIN_PATH. CI tests now depend on GOROOT to tell them which Go version to use and which Go binary to use.
* Set the GOLANGCI_LINT_CACHE, which is used to control where golangci-lint caches information. By default, golangci-lint will use the user's cache directory (usually in the home directory). This prevents the CI linter from writing outside of the working directory.
* Fix setting the PATH variable for the linter.
* Clean up and standardize the makefile.