### PR TITLE
EVG-15448: add check for mod tidy

### DIFF
--- a/cmd/verify-mod-tidy/verify-mod-tidy.go
+++ b/cmd/verify-mod-tidy/verify-mod-tidy.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	goModFile = "go.mod"
+	goSumFile = "go.sum"
+)
+
+// verify-mod-tidy verifies that `go mod tidy` has been run to clean up the
+// go.mod and go.sum files.
+func main() {
+	var (
+		goBin   string
+		timeout time.Duration
+	)
+
+	flag.DurationVar(&timeout, "timeout", 0, "timeout for verifying modules are tidy")
+	flag.StringVar(&goBin, "goBin", "go", "path to go binary to use for mod tidy check")
+	flag.Parse()
+
+	ctx := context.Background()
+	if timeout != 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
+	oldGoMod, oldGoSum, err := readModuleFiles()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	if err := runModTidy(ctx, goBin); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	newGoMod, newGoSum, err := readModuleFiles()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	if !bytes.Equal(oldGoMod, newGoMod) || !bytes.Equal(oldGoSum, newGoSum) {
+		fmt.Fprintf(os.Stderr, "%s and/or %s are not tidy - please run `go mod tidy`.\n", goModFile, goSumFile)
+		writeModuleFiles(oldGoMod, oldGoSum)
+		os.Exit(1)
+	}
+}
+
+// readModuleFiles reads the contents of the go module files.
+func readModuleFiles() (goMod []byte, goSum []byte, err error) {
+	goMod, err = os.ReadFile(goModFile)
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "reading file '%s'", goModFile)
+	}
+	goSum, err = os.ReadFile(goSumFile)
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "reading file '%s'", goSumFile)
+	}
+	return goMod, goSum, nil
+}
+
+// writeModuleFiles writes the contents of the go module files.
+func writeModuleFiles(goMod, goSum []byte) {
+	if err := os.WriteFile(goModFile, goMod, 0600); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+	}
+	if err := os.WriteFile(goSumFile, goSum, 0600); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+	}
+}
+
+// runModTidy runs the `go mod tidy` command with the given go binary.
+func runModTidy(ctx context.Context, goBin string) error {
+	cmd := exec.CommandContext(ctx, goBin, "mod", "tidy")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return errors.Wrap(cmd.Run(), "mod tidy")
+}

--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -63,6 +63,15 @@ tasks:
     tags: ["report"]
     name: lint-recall
 
+  - name: verify-mod-tidy
+    commands:
+      - command: git.get_project
+        type: system
+        params:
+          directory: bond
+      - func: run-make
+        vars: { target: "${task_name}" }
+
 task_groups:
   - name: lintGroup
     tasks: [".report"]
@@ -110,7 +119,8 @@ buildvariants:
       - archlinux-new-small
       - archlinux-new-large
     tasks: 
-      - name: "lintGroup"
+      - name: lintGroup
+      - name: verify-mod-tidy
 
   - name: ubuntu
     display_name: Ubuntu 18.04

--- a/makefile
+++ b/makefile
@@ -130,7 +130,10 @@ $(buildDir)/output.%.lint: $(buildDir)/run-linter .FORCE
 # start module management targets
 mod-tidy:
 	$(gobin) mod tidy
-phony += mod-tidy
+# Check if go.mod and go.sum are clean. If they're clean, then mod tidy should not produce a different result.
+verify-mod-tidy:
+	$(gobin) run cmd/verify-mod-tidy/verify-mod-tidy.go -goBin="$(gobin)"
+phony += mod-tidy verify-mod-tidy
 # end module management targets
 
 # start cleanup targets


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15448

Add a helper Go script and CI task to check if go mod tidy has been run, which is important for keeping the go.mod and go.sum clean. If it hasn't been run, the make target and CI task will fail. I ran it locally to check that it works as expected.